### PR TITLE
switch from parinfer submodule to published library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "parinfer"]
-	path = parinfer
-	url = https://github.com/shaunlebron/parinfer.git

--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ This is, maybe, not optimized enough - it reads and writes the entire buffer wit
 
 # Development
 
-You need to update sub-modules and
-`cd parinfer && lein install`
-
 ###  To build
 `lein cljsbuild auto plugin`
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.170"]
-                 [parinfer "0.1.0-SNAPSHOT"]
+                 [parinfer "0.1.0"]
                  [org.clojure/core.async "0.2.374" :exclusions [org.clojure/tools.reader]]]
 
   :plugins [[lein-cljsbuild "1.1.1"]


### PR DESCRIPTION
just published parinfer to clojars, removing the need for the submodule.