### PR TITLE
Add configurable maps for shifting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ You can `let g:parinfer_mode = "indent"` to switch to indent-mode.
 You can `let g:parinfer_mode = "paren"` to switch to paren-mode.
 
 Indent (`>>`) and dedent (`<<`) mappings have been made to dynamically align elements to tabstops that will change the structure of the code.
+Default mappings can be overridden:
+```VimL
+let g:parinfer_shift_norm_right_map = '<space>>'
+let g:parinfer_shift_norm_left_map = '<space><'
+let g:parinfer_shift_vis_right_map = 'g>'
+let g:parinfer_shift_vis_left_map = 'g<'
+```
 
 You can enable Parinfers previewCursorScope option with `let g:parinfer_preview_cursor_scope = 1` (default is 0)
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -6,6 +6,22 @@ if !exists('g:parinfer_preview_cursor_scope')
   let g:parinfer_preview_cursor_scope = 0
 endif
 
+if !exists('g:parinfer_shift_norm_right_map')
+  let g:parinfer_shift_norm_right_map = '>>'
+endif
+
+if !exists('g:parinfer_shift_norm_left_map')
+  let g:parinfer_shift_norm_left_map = '<<'
+endif
+
+if !exists('g:parinfer_shift_vis_right_map')
+  let g:parinfer_shift_vis_right_map = '>'
+endif
+
+if !exists('g:parinfer_shift_vis_left_map')
+  let g:parinfer_shift_vis_left_map = '<'
+endif
+
 try
   silent! call repeat#set('')
 catch
@@ -92,10 +108,10 @@ augroup Parinfer
         \ :autocmd! Parinfer TextChangedI <buffer>
         \ :call <SID>process("TextChangedI")
 
-  autocmd FileType clojure,scheme,lisp,racket,hy :vmap <buffer> >  <Plug>ParinferShiftVisRight
-  autocmd FileType clojure,scheme,lisp,racket,hy :vmap <buffer> <  <Plug>ParinferShiftVisLeft
-  autocmd FileType clojure,scheme,lisp,racket,hy :nmap <buffer> >> <Plug>ParinferShiftNormRight
-  autocmd FileType clojure,scheme,lisp,racket,hy :nmap <buffer> << <Plug>ParinferShiftNormLeft
+  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_vis_right_map . ' <Plug>ParinferShiftVisRight'
+  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_vis_left_map . ' <Plug>ParinferShiftVisLeft'
+  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_norm_right_map . ' <Plug>ParinferShiftNormRight'
+  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_norm_left_map . ' <Plug>ParinferShiftNormLeft'
 augroup END
 
 if (exists('g:parinfer_airline_integration') ? g:parinfer_airline_integration : 1)

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -108,8 +108,8 @@ augroup Parinfer
         \ :autocmd! Parinfer TextChangedI <buffer>
         \ :call <SID>process("TextChangedI")
 
-  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_vis_right_map . ' <Plug>ParinferShiftVisRight'
-  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_vis_left_map . ' <Plug>ParinferShiftVisLeft'
+  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'vmap <buffer> ' . g:parinfer_shift_vis_right_map . ' <Plug>ParinferShiftVisRight'
+  autocmd FileType clojure,scheme,lisp,racket,hy :exec 'vmap <buffer> ' . g:parinfer_shift_vis_left_map . ' <Plug>ParinferShiftVisLeft'
   autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_norm_right_map . ' <Plug>ParinferShiftNormRight'
   autocmd FileType clojure,scheme,lisp,racket,hy :exec 'nmap <buffer> ' . g:parinfer_shift_norm_left_map . ' <Plug>ParinferShiftNormLeft'
 augroup END


### PR DESCRIPTION
Hi!

The default maps << and >> were interfering with maps I already had, so I made them configurable. 
You can now do something like this in your vimrc:
```VimL
let g:parinfer_shift_norm_right_map = '<space>>'
let g:parinfer_shift_norm_left_map = '<space><'
let g:parinfer_shift_vis_right_map = 'g>'
let g:parinfer_shift_vis_left_map = 'g<'
```